### PR TITLE
Fixed alignment bug with label-wrapper CSS

### DIFF
--- a/src/ui-kit/wrappers/label-wrapper/label-wrapper.template.html
+++ b/src/ui-kit/wrappers/label-wrapper/label-wrapper.template.html
@@ -11,9 +11,8 @@
       <ng-content select="[label-right]"></ng-content>
   </label>
   
-  <div class="toggle-more">
+  <div *ngIf="hint" class="toggle-more">
     <div #hintContainer
-      *ngIf="hint" 
       class="usa-form-hint"
       [attr.id]="hintElId"
       [innerHTML]="hint"


### PR DESCRIPTION
When the toggle-more class was added as a wrapper around the hint container, it wasn't conditional. So a permanent margin for an empty div was added whenever no hint text was supplied. This makes the entire container conditional now, so there is no issue with the margin when no hint is provided.