### PR TITLE
Detach cdr on destroy

### DIFF
--- a/src/ui-kit/form-controls/autocomplete/autocomplete.component.ts
+++ b/src/ui-kit/form-controls/autocomplete/autocomplete.component.ts
@@ -9,7 +9,8 @@ import {
   Optional,
   OnChanges,
   ChangeDetectorRef,
-  TemplateRef
+  TemplateRef,
+  OnDestroy
 } from '@angular/core';
 import {
   NG_VALUE_ACCESSOR,
@@ -44,7 +45,7 @@ interface SamCache{
   providers: [ AUTOCOMPLETE_VALUE_ACCESSOR ]
 })
 export class SamAutocompleteComponent
-  implements ControlValueAccessor, OnChanges, SamCache {
+  implements ControlValueAccessor, OnChanges, OnDestroy, SamCache {
   @ViewChild('resultsList') resultsList: ElementRef;
   @ViewChild('resultsListKV') resultsListKV: ElementRef;
   @ViewChild('input') input: ElementRef;
@@ -295,6 +296,10 @@ export class SamAutocompleteComponent
       this.wrapper.formatErrors(this.control);
       this.cdr.detectChanges();
     }
+  }
+
+  ngOnDestroy (): void {
+    this.cdr.detach();
   }
 
   get errors() {

--- a/src/ui-kit/form-controls/text/text.component.ts
+++ b/src/ui-kit/form-controls/text/text.component.ts
@@ -134,8 +134,8 @@ export class SamTextComponent implements ControlValueAccessor,
   }
 
   public ngOnDestroy (): void {
-    this.cdr.detach();
     this._unsubscribe();
+    this.cdr.detach();
   }
 
   public onLoseFocus (): void {


### PR DESCRIPTION
Detaching CDR on destroy for autocomplete. Changed order in sam-text due to reported bug.