### PR TITLE
Added condition to detectChange on destroyed

### DIFF
--- a/src/ui-kit/form-controls/text/text.component.ts
+++ b/src/ui-kit/form-controls/text/text.component.ts
@@ -160,7 +160,9 @@ export class SamTextComponent implements ControlValueAccessor,
     this.value = value !== null
       ? '' + value
       : '';
-    this.cdr.detectChanges();
+    if (!this.cdr['destroyed']) {
+      this.cdr.detectChanges();
+    }
   }
 
   private _validateInputs (): void {


### PR DESCRIPTION
#Problem:
detectChange() in writeValue()in sam-text is being called after component is destroyed, so it's throwing "ViewDestroyedError" in some fh pages.

#Fix:
added a condition to make sure detectChange() isn't run when the component is destroyed.