### PR TITLE
Use animation package

### DIFF
--- a/src/ui-kit/components/download/download.component.ts
+++ b/src/ui-kit/components/download/download.component.ts
@@ -1,12 +1,8 @@
 import {
   Component,
-  Input,
-  trigger,
-  state,
-  style,
-  transition,
-  animate
+  Input
  } from '@angular/core';
+import { animate, state, style, transition, trigger } from '@angular/animations';
 import { DownloadPackageType } from '../../types';
 
 /**

--- a/src/ui-kit/form-controls/autocomplete-multiselect/autocomplete-multiselect.component.ts
+++ b/src/ui-kit/form-controls/autocomplete-multiselect/autocomplete-multiselect.component.ts
@@ -7,13 +7,8 @@ import {
   Optional,
   forwardRef,
   TemplateRef,
-  trigger,
-  state,
-  style,
-  transition,
-  animate,
-  keyframes
 } from '@angular/core';
+import { animate, state, style, transition, trigger , keyframes} from '@angular/animations';
 import {
   ControlValueAccessor,
   NG_VALUE_ACCESSOR,


### PR DESCRIPTION
In Angular 6, the animation APIs were removed from the `core` package. This PR changes the reference. These changes work with versions of Angular > 4 through the latest, so it isn't breaking.