### PR TITLE
Add option to disable attachment url links

### DIFF
--- a/src/ui-kit/form-controls/upload-v2/upload-v2.template.html
+++ b/src/ui-kit/form-controls/upload-v2/upload-v2.template.html
@@ -35,10 +35,13 @@
               <div class="file-icon" [attr.title]="fctrl?.icon?.name" [attr.id]="uploadElIds.fileToolTip + i" [attr.aria-label]="fctrl?.icon?.name"><i class="p_R-2x" [ngClass]="fctrl?.icon?.iconClass"></i>
               </div>
               <ng-container *ngIf="!fileCtrlConfig[i].isNameEditMode; else fileNameEdit">
-                  <p *ngIf="isEditMode()" [attr.id]="uploadElIds.fileName + i">{{ fctrl.fileName }} </p>
-                  <a *ngIf="!isEditMode()" class="file-link" [attr.id]="uploadElIds.fileLinkId + i" [attr.href]="fctrl.url">{{ fctrl.fileName }} </a>
+                <p *ngIf="isEditMode()" [attr.id]="uploadElIds.fileName + i">{{ fctrl.fileName }} </p>
+                <ng-container *ngIf="!isEditMode()">
+                  <a *ngIf="!fctrl.disabled" class="file-link" [attr.id]="uploadElIds.fileLinkId + i" [attr.href]="fctrl.url">{{ fctrl.fileName }} </a>
+                  <span *ngIf="fctrl.disabled" class="file-link" [attr.id]="uploadElIds.fileLinkId + i">{{ fctrl.fileName }} </span>
+                </ng-container>
                 <div *ngIf="toggleUploadFileAction?.isEdit">
-                  <button type="button"  [attr.id]="uploadElIds.editId + i" class="pull-right inline-pencil-icon clear-button" (click)="onNameEditSwitch(i, $event)" *ngIf="isEditMode()" [attr.aria-label]="uploadElIds.editFileName + i"><i class="fa fa-pencil"></i></button>
+                <button type="button"  [attr.id]="uploadElIds.editId + i" class="pull-right inline-pencil-icon clear-button" (click)="onNameEditSwitch(i, $event)" *ngIf="isEditMode()" [attr.aria-label]="uploadElIds.editFileName + i"><i class="fa fa-pencil"></i></button>
               </div>
               </ng-container>
               <ng-template #fileNameEdit>

--- a/src/ui-kit/types.ts
+++ b/src/ui-kit/types.ts
@@ -338,11 +338,15 @@ export interface UploadedFileData {
   /**
    * sets the url
    */
-  url: string;
-    /**
-     * sets the file icon
-     */
+  url?: string;
+  /**
+   * sets the file icon
+   */
   icon: any;
+  /**
+   * Whether link to download should be disabled
+   */
+  disabled?: boolean;
 }
 
 export interface UploadFileActionModalConfig {


### PR DESCRIPTION
`UploadedFileData` type has new option `disabled`.
If set to true, attachments will show only their name without a link to download.