### PR TITLE
Fix attachment links not passing disabled property through to template

### DIFF
--- a/src/ui-kit/form-controls/upload-v2/upload-v2.component.ts
+++ b/src/ui-kit/form-controls/upload-v2/upload-v2.component.ts
@@ -281,7 +281,7 @@ export class SamUploadComponentV2 implements ControlValueAccessor {
   }
 
   initilizeFileCtrl(
-    {name, size, url, icon},
+    {name, size, url, icon, disabled},
     isSecure = false,
     date = moment().format('MMM DD, YYYY h:mm a')) {
     return {
@@ -294,8 +294,9 @@ export class SamUploadComponentV2 implements ControlValueAccessor {
       originName: name,
       isFirst: false,
       isLast: false,
-     url: url,
-     icon: icon
+      url: url,
+      icon: icon,
+      disabled: disabled,
     };
   }
 


### PR DESCRIPTION
The upload component is not using the passed in uploaded file data directly,
but creating its own object from it to use internally.

We need to copy over the disabled property.