### PR TITLE
[IAE-12045, IAE-12047] Add file upload secure access toggle

### DIFF
--- a/src/ui-kit/form-controls/upload-v2/upload-v2.component.ts
+++ b/src/ui-kit/form-controls/upload-v2/upload-v2.component.ts
@@ -145,7 +145,6 @@ export class SamUploadComponentV2 implements ControlValueAccessor {
 
   /**
    * Sets modal config for remove action
-   * TODO: rename when releasing breaking version
    */
   @Input() public uploadFileActionModalConfig: ActionModalConfig = {};
 
@@ -156,13 +155,11 @@ export class SamUploadComponentV2 implements ControlValueAccessor {
 
   /**
    * Event emitted on remove action modal submit
-   * TODO: rename when releasing breaking version
    */
   @Output() public modalChange: EventEmitter<any> = new EventEmitter<any>();
 
   /**
    * Event emitted on remove action modal open
-   * TODO: rename when releasing breaking version
    */
   @Output() public modalOpen: EventEmitter<any> = new EventEmitter<any>();
 

--- a/src/ui-kit/form-controls/upload-v2/upload-v2.component.ts
+++ b/src/ui-kit/form-controls/upload-v2/upload-v2.component.ts
@@ -481,8 +481,8 @@ export class SamUploadComponentV2 implements ControlValueAccessor {
   }
 
   onToggleModalSubmit(toggleData) {
-    this.toggleModal.closeModal();
     this.toggleModalChange.emit(toggleData[0]);
+    this.toggleModal.closeModal();
   }
 
   onToggleModalClose(toggleData) {

--- a/src/ui-kit/form-controls/upload-v2/upload-v2.component.ts
+++ b/src/ui-kit/form-controls/upload-v2/upload-v2.component.ts
@@ -470,7 +470,9 @@ export class SamUploadComponentV2 implements ControlValueAccessor {
 
   onAccessToggle(fileIndex, secure) {
     let toggleData = {fileIndex, secure};
-    this.toggleModal.openModal(toggleData);
+    if (secure === true) {
+        this.toggleModal.openModal(toggleData);
+    }
     this.toggleAccess.emit(toggleData);
   }
 

--- a/src/ui-kit/form-controls/upload-v2/upload-v2.component.ts
+++ b/src/ui-kit/form-controls/upload-v2/upload-v2.component.ts
@@ -154,9 +154,14 @@ export class SamUploadComponentV2 implements ControlValueAccessor {
   @Output() public modalChange: EventEmitter<any> = new EventEmitter<any>();
 
   /**
-   * Event emitted on modal submit
+   * Event emitted on modal open
    */
   @Output() public modalOpen: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * Event emitted on toggling file access
+   */
+  @Output() public toggleAccess: EventEmitter<any> = new EventEmitter<any>();
 
   public dragState: DragState = DragState.NotDragging;
 
@@ -287,12 +292,16 @@ export class SamUploadComponentV2 implements ControlValueAccessor {
     this.emit();
   }
 
-  initilizeFileCtrl(
-    {name, size, url, icon, disabled},
-    isSecure = false,
-    date = moment().format('MMM DD, YYYY h:mm a')) {
+  initilizeFileCtrl({name, size, url, icon, disabled, isSecure, postedDate}) {
+    if (!isSecure) {
+      isSecure = false;
+    }
+    if (!postedDate) {
+      postedDate = moment().format('MMM DD, YYYY h:mm a');
+    }
+
     return {
-      date,
+      date: postedDate,
       isSecure,
       isNameEditMode: false,
       fileName: name,
@@ -549,6 +558,10 @@ export class SamUploadComponentV2 implements ControlValueAccessor {
     // emit the change event if we select a file, deselect that file,
     // and select the same file again
     this.fileInput.nativeElement.value = '';
+  }
+
+  onAccessToggle(fileIndex, secure) {
+    this.toggleAccess.emit({fileIndex, secure});
   }
 
   private setUploadElementIds() {

--- a/src/ui-kit/form-controls/upload-v2/upload-v2.component.ts
+++ b/src/ui-kit/form-controls/upload-v2/upload-v2.component.ts
@@ -470,7 +470,7 @@ export class SamUploadComponentV2 implements ControlValueAccessor {
 
   onAccessToggle(fileIndex, secure) {
     let toggleData = {fileIndex, secure};
-    if (secure === true) {
+    if (secure) {
         this.toggleModal.openModal(toggleData);
     }
     this.toggleAccess.emit(toggleData);

--- a/src/ui-kit/form-controls/upload-v2/upload-v2.module.ts
+++ b/src/ui-kit/form-controls/upload-v2/upload-v2.module.ts
@@ -6,6 +6,7 @@ import { SamProgressModule } from '../../components/progress-bar';
 import { SamDragDropModule } from '../../directives';
 import { SamFilesizeModule } from '../../pipes';
 import {SamModalModule} from '../../components/modal';
+import { SamToggleSwitchModule } from '../toggle-switch';
 
 @NgModule({
     declarations: [ SamUploadComponentV2 ],
@@ -16,7 +17,8 @@ import {SamModalModule} from '../../components/modal';
         SamDragDropModule,
         SamProgressModule,
         SamFilesizeModule,
-        SamModalModule
+        SamModalModule,
+        SamToggleSwitchModule,
     ]
 })
 export class SamUploadV2Module { }

--- a/src/ui-kit/form-controls/upload-v2/upload-v2.template.html
+++ b/src/ui-kit/form-controls/upload-v2/upload-v2.template.html
@@ -25,7 +25,7 @@
       <thead class="upload-table-header">
         <th scope="col" align="left" class="p_L-4x">Document</th>
         <th scope="col">File Size</th>
-        <th scope="col">Security</th>
+        <th scope="col">Access</th>
         <th scope="col" *ngIf="isEditMode()">Actions</th>
         <th scope="col" *ngIf="!isEditMode()">Updated Date</th>
       </thead>
@@ -62,20 +62,13 @@
               <div [attr.id]="uploadElIds.fileSize + i">{{ fctrl.fileSize | filesize }}</div>
             </td>
             <td class="upload-table-props-col">
-              <div *ngIf="toggleUploadFileAction?.isSecure">
               <ng-container *ngIf="isEditMode(); else secureTag">
-                <input [attr.id]="uploadElIds.fileSecure + i"
-                  name="security-checkbox"
-                  class="secure-cbx"
-                  type="checkbox"
-                  [(ngModel)]="fctrl.isSecure" [attr.aria-label]="uploadElIds.securityCheckboxInput + i"/>
-                <label [attr.id]="uploadElIds.fileSecureLabel + i" class="secure-label">Secure</label>
+                <sam-toggle-switch [attr.id]="uploadElIds.fileSecure + i" [isSwitchOn]="fctrl.isSecure" (switchStatusChange)="onAccessToggle(i, $event)"></sam-toggle-switch>
               </ng-container>
               <ng-template #secureTag>
                 <span class="upload-secure-span" *ngIf="fctrl.isSecure"><i class="fa fa-lock"></i>&nbsp;Secure</span>
                 <span class="upload-secure-span" *ngIf="!fctrl.isSecure"><i class="fa fa-unlock"></i>&nbsp;Not Secure</span>
               </ng-template>
-              </div>
             </td>
             <td class="upload-table-props-col" *ngIf="isEditMode()">
               <div>

--- a/src/ui-kit/form-controls/upload-v2/upload-v2.template.html
+++ b/src/ui-kit/form-controls/upload-v2/upload-v2.template.html
@@ -1,5 +1,5 @@
 <sam-modal *ngIf="uploadFileActionModalConfig"
-  #actionModal
+  #removeModal
   [showClose]="true"
   [closeOnOutsideClick]="true"
   [closeOnEscape]="true"
@@ -8,9 +8,25 @@
   [description]="uploadFileActionModalConfig.description"
   [submitButtonLabel]="'Ok'"
   [cancelButtonLabel]="'Cancel'"
-  (open)="onActionModalOpen($event)"
-  (submit)="onActionModalSubmit($event)">
+  (open)="onRemoveModalOpen($event)"
+  (submit)="onRemoveModalSubmit($event)">
   <ng-content select=".action-modal-content"></ng-content>
+</sam-modal>
+
+<sam-modal *ngIf="toggleAccessActionModalConfig"
+           #toggleModal
+           [showClose]="true"
+           [closeOnOutsideClick]="true"
+           [closeOnEscape]="true"
+           [type]="'warning'"
+           [title]="toggleAccessActionModalConfig.title"
+           [description]="toggleAccessActionModalConfig.description"
+           [submitButtonLabel]="'Ok'"
+           [cancelButtonLabel]="'Cancel'"
+           (open)="onToggleModalOpen($event)"
+           (submit)="onToggleModalSubmit($event)"
+           (close)="onToggleModalClose($event)">
+  <ng-content select=".toggle-modal-content"></ng-content>
 </sam-modal>
 
 <div class="file-container"
@@ -79,7 +95,7 @@
                 <i class="fa fa-chevron-up p_R-1x" [attr.aria-label]="uploadElIds.moveUp + i"></i>
               </button>
              </span>
-              <span *ngIf="toggleUploadFileAction?.isRemove"><button type="button" [attr.id]="uploadElIds.removeId + i" class="clear-button" (click)="onCloseClick(fctrl.fileName, i)">
+              <span *ngIf="toggleUploadFileAction?.isRemove"><button type="button" [attr.id]="uploadElIds.removeId + i" class="clear-button" (click)="onRemoveClick(fctrl.fileName, i)">
                 <i class="fa fa-remove remove-icon" [attr.aria-label]="uploadElIds.removeId + i"></i>
               </button>
                 </span>

--- a/src/ui-kit/form-controls/upload-v2/upload-v2.template.html
+++ b/src/ui-kit/form-controls/upload-v2/upload-v2.template.html
@@ -21,7 +21,7 @@
            [type]="'warning'"
            [title]="toggleAccessActionModalConfig.title"
            [description]="toggleAccessActionModalConfig.description"
-           [submitButtonLabel]="'Ok'"
+           [submitButtonLabel]="'Apply'"
            [cancelButtonLabel]="'Cancel'"
            (open)="onToggleModalOpen($event)"
            (submit)="onToggleModalSubmit($event)"

--- a/src/ui-kit/types.ts
+++ b/src/ui-kit/types.ts
@@ -349,13 +349,13 @@ export interface UploadedFileData {
   disabled?: boolean;
 }
 
-export interface UploadFileActionModalConfig {
+export interface ActionModalConfig {
     /**
-     * sets the upload modal title
+     * sets the modal title
      */
     title?: string,
     /**
-     * sets the upload modal description
+     * sets the modal description
      */
     description?: string
 }


### PR DESCRIPTION
Per [IAE-12045](https://cm-jira.usa.gov/browse/IAE-12045),
- Rename "Security" header to "Access"
- Replace secured file checkbox with a toggle (`sam-toggle-switch`)

Per [IAE-12047](https://cm-jira.usa.gov/browse/IAE-12047),
- Add a new modal for when file access is toggled
- Add event emitters for modal open, submit, and close

When toggled, an event is emitted through a new emitter `toggleAccess`.
It is then up to the client to keep track of toggle state.

We do not keep track of the state within upload component at the moment
since we don't use it and `sam-toggle-switch` already handles UI updates.

*Note: Previously we only had one modal (on removing attachments),
so it was named generically e.g. `actionModal`.

Internal references were renamed to be more descriptive e.g. `removeModal`,
but external facing references are kept the same to avoid breakages.

When the next breaking version is released, the external names should be renamed.