### PR TITLE
Fix radiobutton error message being overwritten

### DIFF
--- a/src/ui-kit/form-controls/radiobutton/radiobutton.component.ts
+++ b/src/ui-kit/form-controls/radiobutton/radiobutton.component.ts
@@ -4,7 +4,8 @@ import {
   Output,
   EventEmitter,
   ViewChild,
-  forwardRef
+  forwardRef,
+  ChangeDetectorRef,
 } from '@angular/core';
 import { FieldsetWrapper } from '../../wrappers/fieldset-wrapper';
 import { OptionsType } from '../../types';
@@ -73,6 +74,8 @@ export class SamRadioButtonComponent  {
   public disabled = undefined;
 
 
+  constructor(private cdr: ChangeDetectorRef) {}
+
   public ngOnInit() {
     if (!this.name) {
       throw new Error('<sam-radio-button> requires a [name]\
@@ -82,12 +85,15 @@ export class SamRadioButtonComponent  {
     if (!this.control) {
       return;
     }
+  }
 
+  public ngAfterViewInit() {
     this.control.valueChanges.subscribe(() => {
       this.wrapper.formatErrors(this.control);
     });
 
     this.wrapper.formatErrors(this.control);
+    this.cdr.detectChanges();
   }
 
   public onRadioChange(value) {


### PR DESCRIPTION
Radiobutton component has two different ways of setting
an error message which overwrite each other.

1. In `ngOnInit` by calling `formatErrors` with the associated form control
2. `errorMessage` property passed in the template

If the form control has an error but no `errorMessage` is set,
the error in the form control will be lost and no errors are shown.

Fixed by moving `formatErrors` call into `afterViewInit` phase.