### PR TITLE
Fix radiobutton NPE when missing control

### DIFF
--- a/src/ui-kit/form-controls/radiobutton/radiobutton.component.ts
+++ b/src/ui-kit/form-controls/radiobutton/radiobutton.component.ts
@@ -81,19 +81,17 @@ export class SamRadioButtonComponent  {
       throw new Error('<sam-radio-button> requires a [name]\
        parameter for 508 compliance');
     }
-
-    if (!this.control) {
-      return;
-    }
   }
 
   public ngAfterViewInit() {
-    this.control.valueChanges.subscribe(() => {
-      this.wrapper.formatErrors(this.control);
-    });
+    if (this.control) {
+      this.control.valueChanges.subscribe(() => {
+        this.wrapper.formatErrors(this.control);
+      });
 
-    this.wrapper.formatErrors(this.control);
-    this.cdr.detectChanges();
+      this.wrapper.formatErrors(this.control);
+      this.cdr.detectChanges();
+    }
   }
 
   public onRadioChange(value) {


### PR DESCRIPTION
Trying to access `this.control` but radiobutton may be used in a way without any formcontrol.