### PR TITLE
adding alt tag for JAWS 17 508 compliance

### DIFF
--- a/src/ui-kit/components/actions/actions-dropdown/actions-dropdown.component.ts
+++ b/src/ui-kit/components/actions/actions-dropdown/actions-dropdown.component.ts
@@ -34,6 +34,7 @@ export class SamActionsDropdownComponent {
    */
   @Input() public buttonType: 'primary'|'default' = 'default';
   @Input() public text: string = 'Actions';
+  @Input() public alt: string = 'Alt';
   /**
    * Emits event when action changes
    */

--- a/src/ui-kit/components/actions/actions-dropdown/actions-dropdown.template.html
+++ b/src/ui-kit/components/actions/actions-dropdown/actions-dropdown.template.html
@@ -9,6 +9,7 @@
           [attr.aria-labelledby]="name"
           [attr.aria-expanded]="showActions ? 'true' : undefined"
           [attr.id]="name"
+          [attr.alt]="alt"
           (click)="toggleActions()"
           (keydown)="leadKeyDownHandler($event)"
           [ngClass]="buttonType === 'primary' ? 'usa-button-primary' : ''"


### PR DESCRIPTION
Adding an "alt" Tag to the sam-actions-dropdown so that we can add specific text to the dropdown if the page we use them on contains multiple for JAWS 508 compliance.