### PR TITLE
Updated to version 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsa-sam/sam-ui-elements",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "SAM UI library",
   "keywords": [
     "angular2",


### PR DESCRIPTION
Update version. This is being published to fix a bug where an interface needs to be made public instead of private. The PR did not get included in the last version that was published.