### PR TITLE
Fix breadcrumbs urlmock accessibility

### DIFF
--- a/src/ui-kit/components/breadcrumbs/breadcrumbs.template.html
+++ b/src/ui-kit/components/breadcrumbs/breadcrumbs.template.html
@@ -7,7 +7,7 @@
       <span>{{crumb.breadcrumb}}</span>
     </ng-container>
     <ng-container *ngIf="crumb.urlmock">
-      <a class="crumb-cursor-pointer" (click)="crumbHandler(crumb.breadcrumb)">{{crumb.breadcrumb}}</a>
+      <a tabindex="0" class="crumb-cursor-pointer" (click)="crumbHandler(crumb.breadcrumb)" (keyup.enter)="crumbHandler(crumb.breadcrumb)">{{crumb.breadcrumb}}</a>
     </ng-container>
   </li>
 </ul>


### PR DESCRIPTION
When we use the `urlmock` option for breadcrumbs, the `<a>` does not have a `href` so it is taken out of the tab order and doesn't have an event handler for enter.

To fix this we need to:
- Add `tabindex` to allow tabbing to the link
- Call click handler on enter keypress as well

Unit tests:
<img width="1197" alt="screen shot 2019-02-22 at 16 00 46" src="https://user-images.githubusercontent.com/22914876/53271016-2cce1b80-36bb-11e9-9484-269d6a3d28db.png">