### PR TITLE
Fix breadcrumbs urlmock accessibility

### DIFF
--- a/src/ui-kit/components/breadcrumbs/breadcrumbs.template.html
+++ b/src/ui-kit/components/breadcrumbs/breadcrumbs.template.html
@@ -7,7 +7,7 @@
       <span>{{crumb.breadcrumb}}</span>
     </ng-container>
     <ng-container *ngIf="crumb.urlmock">
-      <a class="crumb-cursor-pointer" (click)="crumbHandler(crumb.breadcrumb)">{{crumb.breadcrumb}}</a>
+      <a href="javascript:void(0)" class="crumb-cursor-pointer" (click)="crumbHandler(crumb.breadcrumb)" (keyup.enter)="crumbHandler(crumb.breadcrumb)">{{crumb.breadcrumb}}</a>
     </ng-container>
   </li>
 </ul>


### PR DESCRIPTION
When we use the `urlmock` option for breadcrumbs, the `<a>` does not have a `href` so it is taken out of the tab order and doesn't have an event handler for enter.

To fix this we add a dummy `href` and also call the click event handler on enter keypress.

Redo of #272