### PR TITLE
Autocomplete multiselect error message fix

### DIFF
--- a/src/ui-kit/form-controls/autocomplete-multiselect/autocomplete-multiselect.component.ts
+++ b/src/ui-kit/form-controls/autocomplete-multiselect/autocomplete-multiselect.component.ts
@@ -232,6 +232,11 @@ export class SamAutocompleteMultiselectComponent
     if (this.list.length > 0) {
       this.list = this.sortByCategory(this.list);
     }
+    
+  }
+
+  public ngAfterViewInit()
+  {
     if (!this.control) {
       return;
     }

--- a/src/ui-kit/form-controls/autocomplete-multiselect/autocomplete-multiselect.component.ts
+++ b/src/ui-kit/form-controls/autocomplete-multiselect/autocomplete-multiselect.component.ts
@@ -232,7 +232,6 @@ export class SamAutocompleteMultiselectComponent
     if (this.list.length > 0) {
       this.list = this.sortByCategory(this.list);
     }
-    
   }
 
   public ngAfterViewInit()
@@ -245,6 +244,7 @@ export class SamAutocompleteMultiselectComponent
         this.wrapper.formatErrors(this.control);
       });
       this.wrapper.formatErrors(this.control);
+      this.ref.detectChanges();
     } else {
       this.samFormService.formEventsUpdated$.subscribe((evt: any) => {
         if ( (!evt.root || evt.root === this.control.root) &&

--- a/src/ui-kit/form-controls/autocomplete-multiselect/autocomplete-multiselect.spec.ts
+++ b/src/ui-kit/form-controls/autocomplete-multiselect/autocomplete-multiselect.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, FormControl } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { ChangeDetectorRef } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -193,5 +193,14 @@ describe('The Sam Autocomplete Multiselect Component', () => {
         fixture.detectChanges();
         expect(component.value[0]).toBe(component.options[0]);
     });
+
+    it('Should load control error message on init', () => {
+      component.control = new FormControl("");
+      //component.control.setValue("");
+      component.control.markAsDirty();
+      component.control.setErrors({ testValidation: { message: "testMessage"}});
+      fixture.detectChanges();
+      expect(component.wrapper.errorMessage).toBe("testMessage");
+  });
   });
 });


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
<!-- The title will be used to automatically generate release notes through gren -->
<!-- 1. Include the JIRA ticket number in the title (e.g. IAE-500) -->
<!-- 2. Start the title with a verb (e.g. Change header styles) -->
<!-- 3. Use the imperative mood in the title (e.g. Fix, not Fixed or Fixes header styles) -->
<!-- 4. Use labels wisely and assign one label per issue. gren has the option to ignore issues that have one of the specified labels. -->

## Description
<!--- Describe your changes in detail -->
If a form control with an error is passed in, `ngOnInit` would set the message in the label wrapper. However in `autocomplete-multiselect.template.html`, the `errorMessage` input value would override it. Pushing `this.wrapper.formatErrors(this.control);` into ngAfterViewInit so the above scenario is avoided.

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

