### PR TITLE
IAE 16714 Label wrapper "more/less" link accessibility issues 

### DIFF
--- a/src/ui-kit/wrappers/label-wrapper/label-wrapper.template.html
+++ b/src/ui-kit/wrappers/label-wrapper/label-wrapper.template.html
@@ -19,8 +19,9 @@
       [style.overflow]="setOverflow()"
       [style.height]="setHeight()">
     </div>
+  
     <div *ngIf="showToggle && !showFullHint">
-      <a href="javascript:void(0)" [attr.aria-label]="toggleOpen ? 'Less info for' : 'More info for' + name "
+      <a href="javascript:void(0)" [attr.aria-label]="toggleOpen ? 'Less info for ' + label : 'More info for ' + label "
         (click)="toggleHint(toggleOpen)">
         {{ toggleOpen ? "less": "more" }}
       </a>

--- a/src/ui-kit/wrappers/label-wrapper/label-wrapper.template.html
+++ b/src/ui-kit/wrappers/label-wrapper/label-wrapper.template.html
@@ -20,7 +20,7 @@
       [style.height]="setHeight()">
     </div>
     <div *ngIf="showToggle && !showFullHint">
-      <a href="javascript:void(0)"
+      <a href="javascript:void(0)" [attr.aria-label]="toggleOpen ? 'Less info for' : 'More info for' + name "
         (click)="toggleHint(toggleOpen)">
         {{ toggleOpen ? "less": "more" }}
       </a>


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
<!-- The title will be used to automatically generate release notes through gren -->
<!-- 1. Include the JIRA ticket number in the title (e.g. IAE-500) -->
<!-- 2. Start the title with a verb (e.g. Change header styles) -->
<!-- 3. Use the imperative mood in the title (e.g. Fix, not Fixed or Fixes header styles) -->
<!-- 4. Use labels wisely and assign one label per issue. gren has the option to ignore issues that have one of the specified labels. -->

## Description
Added Aria label for label-wrapper
<!--- Describe your changes in detail -->

## Motivation and Context
https://cm-jira.usa.gov/browse/IAE-16714
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [x] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

