### PR TITLE
IAE-18688 display multiple control validation error messages and extension error msg text change

### DIFF
--- a/src/ui-kit/form-templates/international-phone/sam-extension/extension.component.ts
+++ b/src/ui-kit/form-templates/international-phone/sam-extension/extension.component.ts
@@ -107,7 +107,7 @@ export class SamExtension extends SamFormControl {
   private extensionValidator (c: FormControl) {
     const regex: RegExp = /^[0-9]{1,20}$/g;
     const message =
-      'Phone extensions must be less than 20 numbers';
+      'Phone extensions must be 20 digits or fewer';
 
     return c && c.value && !c.value.toString().match(regex)
       ? { extension: { message: message } }

--- a/src/ui-kit/form-templates/international-phone/sam-extension/extension.component.ts
+++ b/src/ui-kit/form-templates/international-phone/sam-extension/extension.component.ts
@@ -107,7 +107,7 @@ export class SamExtension extends SamFormControl {
   private extensionValidator (c: FormControl) {
     const regex: RegExp = /^[0-9]{1,20}$/g;
     const message =
-      'Phone extensions must be 20 numbers or fewer';
+      'Phone extensions must be less than 20 numbers';
 
     return c && c.value && !c.value.toString().match(regex)
       ? { extension: { message: message } }

--- a/src/ui-kit/form-templates/international-phone/sam-extension/extension.component.ts
+++ b/src/ui-kit/form-templates/international-phone/sam-extension/extension.component.ts
@@ -107,7 +107,7 @@ export class SamExtension extends SamFormControl {
   private extensionValidator (c: FormControl) {
     const regex: RegExp = /^[0-9]{1,20}$/g;
     const message =
-      'Phone extensions must only include numbers';
+      'Phone extensions must be less than 20 numbers';
 
     return c && c.value && !c.value.toString().match(regex)
       ? { extension: { message: message } }

--- a/src/ui-kit/form-templates/international-phone/sam-extension/extension.component.ts
+++ b/src/ui-kit/form-templates/international-phone/sam-extension/extension.component.ts
@@ -107,7 +107,7 @@ export class SamExtension extends SamFormControl {
   private extensionValidator (c: FormControl) {
     const regex: RegExp = /^[0-9]{1,20}$/g;
     const message =
-      'Phone extensions must be less than 20 numbers';
+      'Phone extensions must be 20 numbers or fewer';
 
     return c && c.value && !c.value.toString().match(regex)
       ? { extension: { message: message } }

--- a/src/ui-kit/form-templates/international-phone/sam-international-prefix/international-prefix.component.ts
+++ b/src/ui-kit/form-templates/international-phone/sam-international-prefix/international-prefix.component.ts
@@ -93,7 +93,7 @@ export class SamInternationalPrefix extends SamFormControl {
   private countryCodeValidator (c: FormControl) {
     const regex: RegExp = /^[0-9]{1,3}$/g;
     const message =
-      'Country codes must be 3 numbers or fewer';
+      'Country codes must be 3 digits or fewer';
 
     return c && c.value && !c.value.toString().match(regex)
       ? { countryCode: { message: message } }

--- a/src/ui-kit/form-templates/international-phone/sam-international-prefix/international-prefix.spec.ts
+++ b/src/ui-kit/form-templates/international-phone/sam-international-prefix/international-prefix.spec.ts
@@ -38,7 +38,7 @@ describe('Sam International Prefix', () => {
   
     it('should invalidate country code > 999', () => {
       const value = 1000;
-      const errMsg = 'Country codes must be 3 numbers or fewer';
+      const errMsg = 'Country codes must be 3 digits or fewer';
       const control = new FormControl();
       control.setValue(value);
   

--- a/src/ui-kit/form-templates/international-phone/sam-telephone/telephone.component.ts
+++ b/src/ui-kit/form-templates/international-phone/sam-telephone/telephone.component.ts
@@ -180,8 +180,7 @@ export class SamTelephone extends SamFormControl
     return (c: FormControl): { [key: string]: any } => {
       const usaRegex: RegExp = /^[0-9]{10}$/g;
       const message =
-        'North American phone numbers must be 10 numbers \
-        in length';
+        'North American phone numbers must be 10 digits';
       
       return c && c.value && !c.value.match(usaRegex)
         ? { usaPhone: { message: message } }
@@ -193,8 +192,7 @@ export class SamTelephone extends SamFormControl
 
     return (c: FormControl): { [key: string]: any} => {
       const message =
-        'International phone numbers include between 4 \
-        and 15 numbers';
+        'International phone numbers must be between 4 and 15 digits';
 
       return c && c.value && this.isValidIntlNumber(c.value)
         ? { intlPhone: { message: message } }

--- a/src/ui-kit/wrappers/fieldset-wrapper/fieldset-wrapper.component.ts
+++ b/src/ui-kit/wrappers/fieldset-wrapper/fieldset-wrapper.component.ts
@@ -31,7 +31,7 @@ export class FieldsetWrapper {
     if (!!message) {
       this.errorMessages = [];
       this.errorMessages.push(message);
-    } else if(!(this.errorMessages.length > 0)){
+    } else if(this.errorMessages.length === 0){
       this.errorMessages = [];
     }
   };
@@ -153,20 +153,15 @@ export class FieldsetWrapper {
     if (!control) {
       return;
     }
-    // Removed to display error messaage when component have multple control validation
-    // if (control.pristine) {
-    //   this.errorMessage = '';
-    //   return;
-    // }
-  
+    
     if (control.invalid && control.errors) {
       this.formatInvalidErrors(control);
     } else if (!control.errors) {
       this.errorMessage = '';
   }
   }
-
-  private formatInvalidErrors(control) {
+ 
+  private formatInvalidErrors(control: AbstractControl) {
     for (const k in control.errors) {
       const errorObject = control.errors[k];
 

--- a/src/ui-kit/wrappers/fieldset-wrapper/fieldset-wrapper.component.ts
+++ b/src/ui-kit/wrappers/fieldset-wrapper/fieldset-wrapper.component.ts
@@ -31,7 +31,7 @@ export class FieldsetWrapper {
     if (!!message) {
       this.errorMessages = [];
       this.errorMessages.push(message);
-    } else {
+    } else if(!(this.errorMessages.length > 0)){
       this.errorMessages = [];
     }
   };
@@ -153,17 +153,17 @@ export class FieldsetWrapper {
     if (!control) {
       return;
     }
-
-    if (control.pristine) {
-      this.errorMessage = '';
-      return;
-    }
-
+    // Removed to display error messaage when component have multple control validation
+    // if (control.pristine) {
+    //   this.errorMessage = '';
+    //   return;
+    // }
+  
     if (control.invalid && control.errors) {
       this.formatInvalidErrors(control);
     } else if (!control.errors) {
-        this.errorMessage = '';
-    }
+      this.errorMessage = '';
+  }
   }
 
   private formatInvalidErrors(control) {

--- a/src/ui-kit/wrappers/fieldset-wrapper/fieldset-wrapper.spec.ts
+++ b/src/ui-kit/wrappers/fieldset-wrapper/fieldset-wrapper.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/core/testing';
 import { Component, ChangeDetectorRef } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { FormControl } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 // Load the implementations that should be tested
 import {FieldsetWrapper} from './fieldset-wrapper.component';
 
@@ -22,9 +22,40 @@ describe('The Sam Fieldset Wrapper component', () => {
      * rendered tests. Not sure how rendered tests are even running
      * this test to begin with.
      */
+    it('should not clear error message when errormessages list greater than 0', () => {
+      component.errorMessages = [];
+     const group = new FormGroup(
+        {
+          prefix: new FormControl('1'),
+          phone: new FormControl('1234567'),
+          extension: new FormControl('')
+        }
+      );
+      group.controls.prefix.setErrors({
+        required: true
+      });
+      group.controls.phone.setErrors({
+        required: true
+      });
+      component.formatErrors(group.controls.prefix, group.controls.phone, group.controls.extension);
+      expect(component.errorMessages.length).toBe(2);
+    });
+    it('should clear error message when errormessages list is 0', () => {
+      component.errorMessages = [];
+     const group = new FormGroup(
+        {
+          prefix: new FormControl('1'),
+          phone: new FormControl('1234567'),
+          extension: new FormControl('')
+        }
+      );
+      component.formatErrors(group.controls.prefix, group.controls.phone, group.controls.extension);
+      expect(component.errorMessages.length).toBe(0);
+    });
+
     it('should display error messages with a form control', () => {
       component.formatErrors(undefined);
-        
+
       const control = new FormControl('');
       component.formatErrors(control);
       expect(component.errorMessage).toBe(undefined);


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
<!-- The title will be used to automatically generate release notes through gren -->
<!-- 1. Include the JIRA ticket number in the title (e.g. IAE-500) -->
<!-- 2. Start the title with a verb (e.g. Change header styles) -->
<!-- 3. Use the imperative mood in the title (e.g. Fix, not Fixed or Fixes header styles) -->
<!-- 4. Use labels wisely and assign one label per issue. gren has the option to ignore issues that have one of the specified labels. -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
https://cm-jira.usa.gov/browse/IAE-18688#
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11
- [x] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [x] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

