### PR TITLE
date component - emit event if pristine and inputs already have values

### DIFF
--- a/src/ui-kit/form-controls/date/date.component.ts
+++ b/src/ui-kit/form-controls/date/date.component.ts
@@ -469,7 +469,10 @@ export class SamDateComponent
 
   onChangeHandler(override = undefined) {
     this.onTouched();
-    if (this.isDateTouched && this.isMonthTouched && this.isYearTouched && !this.isTabPressed) {
+    let dayCheck = this.isDateTouched || (!this.isDateTouched && this.day.nativeElement.value);
+    let monthCheck = this.isMonthTouched || (!this.isMonthTouched && this.month.nativeElement.value);
+    let yearCheck = this.isYearTouched || (!this.isYearTouched && this.year.nativeElement.value);
+    if (dayCheck && monthCheck && yearCheck && !this.isTabPressed) {
       if (this.month.nativeElement.value || this.day.nativeElement.value ||
         this.year.nativeElement.value) {
         if (this.isClean(override)) {

--- a/src/ui-kit/form-controls/date/date.spec.ts
+++ b/src/ui-kit/form-controls/date/date.spec.ts
@@ -143,6 +143,15 @@ describe('The Sam Date component', () => {
       expect(component.year.nativeElement.value).toBe('2016');
     });
 
+    it('should fire change events if prepopulated and at least one field is not pristine', function(){
+      component.isDateTouched = false;
+      component.isMonthTouched = false;
+      component.isYearTouched = true;
+      component.valueChange.subscribe((data)=>{
+        expect(data).toBe("2016-12-29");
+      });
+      component.onChangeHandler();
+    });
   });
 
   describe('Tab key tests', () => {


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
<!-- The title will be used to automatically generate release notes through gren -->
<!-- 1. Include the JIRA ticket number in the title (e.g. IAE-500) -->
<!-- 2. Start the title with a verb (e.g. Change header styles) -->
<!-- 3. Use the imperative mood in the title (e.g. Fix, not Fixed or Fixes header styles) -->
<!-- 4. Use labels wisely and assign one label per issue. gren has the option to ignore issues that have one of the specified labels. -->

## Description
<!--- Describe your changes in detail -->
The date component isn't emitting change events if pre-populated, all inputs are pristine, and changing only one field

Current issue:
![date-before](https://user-images.githubusercontent.com/7127587/65718194-11702800-e071-11e9-820e-03fba7eb7186.gif)

After fix:
![date-after](https://user-images.githubusercontent.com/7127587/65718202-1503af00-e071-11e9-80f4-ae40ca3b94d4.gif)


## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

