### PR TITLE
autocomplete ie11 placeholder fix

### DIFF
--- a/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.html
+++ b/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.html
@@ -2,7 +2,7 @@
   <div class="input-container">
     <div role="combobox" [attr.id]="configuration.id+'-container'" [attr.aria-expanded]="showResults"
       [attr.aria-owns]="showResults? configuration.id+ '-listbox' : undefined" aria-haspopup="listbox">
-      <input [disabled]="disabled" (ngModelChange)="textChange($event)" class="sam input" #input
+      <input (input)="textChange($event)" [disabled]="disabled" class="sam input" #input
         [attr.id]="configuration.id" type="text" (focus)="inputFocusHandler()" (keydown)="onKeydown($event)"
         [(ngModel)]="inputValue" aria-autocomplete="list" [attr.placeholder]="configuration.autocompletePlaceHolderText"
         [attr.aria-activedescendant]="showResults? configuration.id+'-resultItem-'+highlightedIndex :''"

--- a/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.spec.ts
+++ b/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.spec.ts
@@ -59,7 +59,12 @@ describe('SamAutocompleteComponent', () => {
 
   it('Should have empty results with invalid search', fakeAsync(() => {
 
-    const event = 'test search';
+    const event = {
+      preventDefault: ()=>{},
+      target: component.input.nativeElement
+    };
+    component.input.nativeElement.value = "test search";
+    component.input.nativeElement.focus();
     component.textChange(event);
     fixture.detectChanges();
     tick();
@@ -72,7 +77,12 @@ describe('SamAutocompleteComponent', () => {
 
   it('Should have results with minimumCharacterCountSearch', fakeAsync(() => {
 
-    const event ='Level 7' 
+    const event = {
+      preventDefault: ()=>{},
+      target: component.input.nativeElement
+    };
+    component.input.nativeElement.value = "Level 7";
+    component.input.nativeElement.focus();
     component.configuration.minimumCharacterCountSearch = 3;
     component.textChange(event);
     fixture.detectChanges();
@@ -88,7 +98,12 @@ describe('SamAutocompleteComponent', () => {
 
 
   it('Should have results key press', fakeAsync(() => {
-    const event ='id';
+    const event = {
+      preventDefault: ()=>{},
+      target: component.input.nativeElement
+    };
+    component.input.nativeElement.value = "id";
+    component.input.nativeElement.focus();
     component.textChange(event);
     fixture.detectChanges();
     tick();
@@ -204,7 +219,12 @@ describe('SamAutocompleteComponent', () => {
 
 
   it('Should have delete have results', fakeAsync(() => {
-    const event = 'id' ;
+    const event = {
+      preventDefault: ()=>{},
+      target: component.input.nativeElement
+    };
+    component.input.nativeElement.value = "id";
+    component.input.nativeElement.focus();
     component.textChange(event);
     fixture.detectChanges();
     tick();

--- a/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.ts
+++ b/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.ts
@@ -188,8 +188,14 @@ export class SAMSDSAutocompleteSearchComponent implements ControlValueAccessor {
     }
   }
 
-  textChange(event) {
-    const searchString = event || '';
+  textChange(event){
+    // ie 11 placeholders will incorrectly trigger input events (known bug)
+    // if input isn't active element then don't do anything
+    if(event.target != document.activeElement){
+      event.preventDefault();
+      return;
+    }
+    const searchString = event.target.value || '';
     this.getResults(searchString);
   }
 


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
<!-- The title will be used to automatically generate release notes through gren -->
<!-- 1. Include the JIRA ticket number in the title (e.g. IAE-500) -->
<!-- 2. Start the title with a verb (e.g. Change header styles) -->
<!-- 3. Use the imperative mood in the title (e.g. Fix, not Fixed or Fixes header styles) -->
<!-- 4. Use labels wisely and assign one label per issue. gren has the option to ignore issues that have one of the specified labels. -->

## Description
<!--- Describe your changes in detail -->
in ie11, having a placeholder incorrectly fires input events after clicking away or making a selection in the dropdown. Adding a fix

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

