### PR TITLE
Allow sam-date to emit null on deleting date

### DIFF
--- a/src/ui-kit/form-controls/date/date.component.ts
+++ b/src/ui-kit/form-controls/date/date.component.ts
@@ -475,7 +475,7 @@ export class SamDateComponent
     let monthCheck = this.isMonthTouched || (!this.isMonthTouched && this.month.nativeElement.value);
     let yearCheck = this.isYearTouched || (!this.isYearTouched && this.year.nativeElement.value);
     if (dayCheck && monthCheck && yearCheck && !this.isTabPressed) {
-      if (this.isClean(override)) {
+      if (this.isEmptyField(override)) {
         this.onChange(null);
         this.valueChange.emit(null);
       } else if (this.isYearTouched) {
@@ -518,7 +518,7 @@ export class SamDateComponent
       this.onChangeHandler(dupModel);
     }
   }
-  isClean(override = undefined) {
+  isEmptyField(override = undefined) {
     let dupModel = this.inputModel;
     if (override) {
       dupModel = override;

--- a/src/ui-kit/form-controls/date/date.component.ts
+++ b/src/ui-kit/form-controls/date/date.component.ts
@@ -475,29 +475,26 @@ export class SamDateComponent
     let monthCheck = this.isMonthTouched || (!this.isMonthTouched && this.month.nativeElement.value);
     let yearCheck = this.isYearTouched || (!this.isYearTouched && this.year.nativeElement.value);
     if (dayCheck && monthCheck && yearCheck && !this.isTabPressed) {
-      if (this.month.nativeElement.value || this.day.nativeElement.value ||
-        this.year.nativeElement.value) {
-        if (this.isClean(override)) {
-          this.onChange(null);
-          this.valueChange.emit(null);
-        } else if (this.isYearTouched) {
-          if (this.year.nativeElement.value.length != 4) {
-            this.onChange('Invalid Date');
-            this.valueChange.emit('Invalid Date');
-          } else {
-            const dateString = this.getDate(override).format(this.OUTPUT_FORMAT);
-            this.onChange(dateString);
-            this.valueChange.emit(dateString);
-          }
-        } else if ((!this.getDate(override).isValid())) {
+      if (this.isClean(override)) {
+        this.onChange(null);
+        this.valueChange.emit(null);
+      } else if (this.isYearTouched) {
+        if (this.year.nativeElement.value.length != 4) {
           this.onChange('Invalid Date');
           this.valueChange.emit('Invalid Date');
         } else {
-          // use the strict format for outputs
           const dateString = this.getDate(override).format(this.OUTPUT_FORMAT);
           this.onChange(dateString);
           this.valueChange.emit(dateString);
         }
+      } else if ((!this.getDate(override).isValid())) {
+        this.onChange('Invalid Date');
+        this.valueChange.emit('Invalid Date');
+      } else {
+        // use the strict format for outputs
+        const dateString = this.getDate(override).format(this.OUTPUT_FORMAT);
+        this.onChange(dateString);
+        this.valueChange.emit(dateString);
       }
     }
     this.focusHandler();


### PR DESCRIPTION
## Description
When a user has not added a date, sam-date emits null.
But when a user adds a date then deletes it, sam-date emits Invalid Date.
Sam-date should emit null in both cases to be consistent.

## Motivation and Context
We need to distinguish between invalid date and empty date to determine whether to activate submit button on a date range filter. If start date is valid and end date is empty, user is allowed to filter. But if start date is valid and end date is invalid, user is not allowed to filter.

## Type of Change (Select One and Apply Github Label)
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [x] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [x] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

