### PR TITLE
Resolve UI issues with sds-autocomplete component

### DIFF
--- a/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.html
+++ b/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.html
@@ -69,6 +69,8 @@
         </span>
       </span>
     </ng-container>
-    <ul #srOnly class="usa-sr-only" aria-live="assertive" aria-relevant="additions"></ul>
+    <ul class="usa-sr-only" aria-live="assertive">
+      <li>{{srOnlyText}}</li>
+    </ul>
   </div>
 </div>

--- a/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.spec.ts
+++ b/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.spec.ts
@@ -376,6 +376,14 @@ describe('SamAutocompleteComponent', () => {
   });
 
 
+  it('should have reference to resultslist element defined after results on focus are populated', fakeAsync(() => {
+    component.inputFocusHandler();
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(component.resultsListElement).toBeDefined();
+  }));
 
 });
 

--- a/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.ts
+++ b/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.ts
@@ -23,17 +23,13 @@ export class SAMSDSAutocompleteSearchComponent implements ControlValueAccessor {
   /**
    * Ul list of elements 
    */
-  @ViewChild('resultsList', {static: true}) resultsListElement: ElementRef;
+  @ViewChild('resultsList', {static: false}) resultsListElement: ElementRef;
 
   /**
    * input control 
    */
   @ViewChild('input', {static: true}) input: ElementRef;
 
-  /**
-   * Screen read field
-   */
-  @ViewChild('srOnly', {static: true}) srOnly: ElementRef;
 
   /**
    * Allow to insert a customized template for suggestions to use
@@ -98,6 +94,13 @@ export class SAMSDSAutocompleteSearchComponent implements ControlValueAccessor {
    * Search string
    */
   private searchString: string = null;
+
+  /**
+   * Message announced by screen readers when
+   * autocomplete results are updated or new item
+   * is highlighted
+   */
+  public srOnlyText: string;
 
   /**
    * Stored Event for ControlValueAccessor
@@ -445,11 +448,7 @@ export class SAMSDSAutocompleteSearchComponent implements ControlValueAccessor {
    * @param message 
    */
   private addScreenReaderMessage(message: string) {
-    const srResults: HTMLElement = document.createElement('li');
-    srResults.innerText = message;
-    if (this.srOnly && this.srOnly.nativeElement) {
-      this.srOnly.nativeElement.appendChild(srResults);
-    }
+    this.srOnlyText = message;
   }
 
 


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
<!-- The title will be used to automatically generate release notes through gren -->
<!-- 1. Include the JIRA ticket number in the title (e.g. IAE-500) -->
<!-- 2. Start the title with a verb (e.g. Change header styles) -->
<!-- 3. Use the imperative mood in the title (e.g. Fix, not Fixed or Fixes header styles) -->
<!-- 4. Use labels wisely and assign one label per issue. gren has the option to ignore issues that have one of the specified labels. -->

## Description
Resolves two issues - 
1. SDS autocomplete search not making query for additional data once user scrolls to current limit
2. Additional whitespace being created at the bottom of the page as user hovers over autocomplete results

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

<img width="1674" alt="Screen Shot 2020-03-12 at 10 54 35 AM" src="https://user-images.githubusercontent.com/21962304/76534928-83d29a00-6450-11ea-909a-aaef845018b4.png">

<img width="1481" alt="Screen Shot 2020-03-12 at 10 55 41 AM" src="https://user-images.githubusercontent.com/21962304/76534976-92b94c80-6450-11ea-8af9-0fa649132e0b.png">


## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

