### PR TITLE
Adjust config for sam text and announce wrapper more/less state

### DIFF
--- a/src/ui-kit/form-controls/text/text.component.ts
+++ b/src/ui-kit/form-controls/text/text.component.ts
@@ -92,6 +92,12 @@ export class SamTextComponent implements ControlValueAccessor,
    * Sets the title attribute on the input for accessibility
    */
   @Input() public title: string;
+
+  /**
+   * Sets full hint toggle option for label wrapper
+   */
+  @Input() public showFullHint: boolean = false;
+
   /**
    * Changes the HTML event the changes emit on
    */

--- a/src/ui-kit/form-controls/text/text.template.html
+++ b/src/ui-kit/form-controls/text/text.template.html
@@ -3,6 +3,7 @@
   [name]="id ? id : name"
   [hint]="hint"
   [errorMessage]="errorMessage"
+  [showFullHint]="showFullHint"
   [required]="required">
   <input
     type="text"

--- a/src/ui-kit/wrappers/label-wrapper/label-wrapper.template.html
+++ b/src/ui-kit/wrappers/label-wrapper/label-wrapper.template.html
@@ -11,7 +11,7 @@
       <ng-content select="[label-right]"></ng-content>
   </label>
   
-  <div *ngIf="hint" class="toggle-more">
+  <div *ngIf="hint" class="toggle-more" aria-live="polite">
     <div #hintContainer
       class="usa-form-hint"
       [attr.id]="hintElId"
@@ -22,6 +22,7 @@
   
     <div *ngIf="showToggle && !showFullHint">
       <a href="javascript:void(0)" [attr.aria-label]="toggleOpen ? 'Less info for ' + label : 'More info for ' + label "
+        [attr.aria-expanded]="toggleOpen" [attr.aria-controls]="hintElId"
         (click)="toggleHint(toggleOpen)">
         {{ toggleOpen ? "less": "more" }}
       </a>


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
<!-- The title will be used to automatically generate release notes through gren -->
<!-- 1. Include the JIRA ticket number in the title (e.g. IAE-500) -->
<!-- 2. Start the title with a verb (e.g. Change header styles) -->
<!-- 3. Use the imperative mood in the title (e.g. Fix, not Fixed or Fixes header styles) -->
<!-- 4. Use labels wisely and assign one label per issue. gren has the option to ignore issues that have one of the specified labels. -->

## Description
1. Adds an additional input to sam text components that allow clients to control display of more / less hint in label wrapper.
2. Adds aria-expanded attribute to more / less link in sam-label-wrapper so that JAWS announces the state of the link (expanded or collapsed)
3. Adds aria-live attribute to the element containing the hint so that the hint is re-read by jaws upon toggling more / less link.

What this change DOES NOT DO:
Jaws will always announce the full hint even if less hint is being displayed. This is because the CSS used to hide the extra text is not removed from DOM, simply hidden from users' sight.

## Motivation and Context
[IAE-28070] - Jaws not announcing state of more / less link

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ x ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ x ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

Test status:
![image](https://user-images.githubusercontent.com/21962304/78055966-59d70e00-7352-11ea-98ee-1b26c22f99a4.png)


