### PR TITLE
IAE-38509 & IAE-38521 - allow custom aria label for checkboxes, radio buttons, and toggle switch

### DIFF
--- a/src/ui-kit/form-controls/checkbox/checkbox.template.html
+++ b/src/ui-kit/form-controls/checkbox/checkbox.template.html
@@ -5,7 +5,8 @@
       <label [attr.for]="checkAllLabelOrId()">Select all</label>
     </li>
     <li *ngFor="let option of options; let i = index">
-      <input [disabled]="option.disabled || disabled?'disabled':null" [attr.id]="option.name" [attr.aria-label]="option.label" type="checkbox"
+      <input [disabled]="option.disabled || disabled?'disabled':null" [attr.id]="option.name" 
+        [attr.aria-label]="option.ariaLabel ? option.ariaLabel : option.label" type="checkbox"
         (change)="onCheckChanged(option.value, $event.target.checked, option.name)" [checked]="isChecked(option.value)">
       <label [attr.aria-hidden]="true" [attr.for]="option.name">{{option.label}}</label>
     </li>

--- a/src/ui-kit/form-controls/radiobutton/radiobutton.template.html
+++ b/src/ui-kit/form-controls/radiobutton/radiobutton.template.html
@@ -6,7 +6,7 @@
   <ul class="usa-unstyled-list">
     <li *ngFor="let option of options; let i = index">
       <input [attr.id]="option.name"
-        [attr.aria-label]="option.label"
+        [attr.aria-label]="option.ariaLabel ? option.ariaLabel : option.label"
         type="radio"
         (change)="onRadioChange(option.value)"
         [attr.disabled]="option.disabled || disabled ? 'disabled': undefined"

--- a/src/ui-kit/form-controls/toggle-switch/toggle-switch.template.html
+++ b/src/ui-kit/form-controls/toggle-switch/toggle-switch.template.html
@@ -1,5 +1,6 @@
 <label class="sam-toggle-switch">
-  <input class="switch-input" role="switch" type="checkbox" [(ngModel)]="isSwitchOn" (click)="onSwitchClick($event)" [attr.disabled]="disableSwitch ? disableSwitch : null">
+  <input class="switch-input" role="switch" type="checkbox"
+    [attr.aria-label]="toggleSwitchText"
+    [(ngModel)]="isSwitchOn" (click)="onSwitchClick($event)" [attr.disabled]="disableSwitch ? disableSwitch : null">
   <div class="switch-label"></div>
-  <span class="sr-only">{{toggleSwitchText}}</span>
 </label>

--- a/src/ui-kit/types.ts
+++ b/src/ui-kit/types.ts
@@ -11,13 +11,17 @@ export interface OptionsType {
    */
   label: string;
   /**
-   * The machine readable description of the input
+   * The name and id attribute value of the input
    */
   name: string;
   /**
    * if true, the option is greyed out and not clickable
    */
   disabled?: boolean;
+  /**
+   * The machine read description of the input. Will default to label value if none is provided
+   */
+  ariaLabel?: string
 }
 
 export interface AutocompleteDropdownButton {


### PR DESCRIPTION
## Description
This change adds an optional ariaLabel property to OptionsType object that is used to specify what JAWS should announce when focus moves to a radio or checkbox item. Previously we were simply using the visible label passed in as the aria label property of the checkbox or radio. That feature is kept as default if no ariaLabel property is provided. This extends the functionality such that if the clients want some customized screen reader only message instead of the visible label, they may do so. Additionally, it moves the toggleSwitchText input as an aria-label field for toggle switch. Previously, there was a separate sr-only span tag for JAWS to announce description of the toggle switch. However, this was failing 508 check with ANDI as the toggle switch input field itself did not have an accessible field.

## Motivation and Context
https://cm-jira.usa.gov/browse/IAE-38509 - Here I would like JAWS to announce not just the label, but the custom html next to the label as well.
https://cm-jira.usa.gov/browse/IAE-38521 - Toggle switch did not have accessible name

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ x ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

