### PR TITLE
Resolve single select bug on autocomplete, update package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsa-sam/sam-ui-elements",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "SAM UI library",
   "repository": {
     "type": "git",

--- a/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete/autocomplete.component.ts
+++ b/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete/autocomplete.component.ts
@@ -72,7 +72,7 @@ export class SAMSDSAutocompleteComponent implements ControlValueAccessor {
   @Input()
   public service: SAMSDSAutocompleteServiceInterface;
 
-  @ViewChild("autocompleteSearch", { static: false })
+  @ViewChild("autocomplete", { static: false })
   autocompleteSearch: SAMSDSAutocompleteSearchComponent;
   constructor(private cd: ChangeDetectorRef) {}
 
@@ -103,10 +103,8 @@ export class SAMSDSAutocompleteComponent implements ControlValueAccessor {
       this.model.items = value;
       this.cd.markForCheck();
     } else {
-      if (!this.model || !(this.model instanceof SAMSDSSelectedItemModel)) {
-        this.model = new SAMSDSSelectedItemModel();
-      }
-      this.model.items = value && value.items ? value.items : [];
+      const items = value && value.items ? value.items : [];
+      this.model = new SAMSDSSelectedItemModel(items);
       this.cd.markForCheck();
     }
   }


### PR DESCRIPTION
The changes here fix issue seen with agency picker in single select mode in sam-front-end3. If the ngModel of the autocomplete is changed from an external component (the agency picker modal in this case), that change was not reflected in the autocomplete input field. This is because the `autocomplete.component.ts` was modifying the model in such a way that the reference to the model itself was not changed. So the internal component - `autocomplete-search.component.ts` would not fire its writeValue method to update the input because the reference to its ngModel was not changed, just the items array in the ngModel object. This change resolves the issue by letting `autocomplete.component.ts` create a new instance of the model object rather than just modifying the items array, which forces the `autocomplete-search.component.ts` to register the change in ngModel value, and update accordingly.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

