### PR TITLE
Resolve amp violation for download modal

### DIFF
--- a/src/ui-kit/components/modal/modal.component.ts
+++ b/src/ui-kit/components/modal/modal.component.ts
@@ -77,6 +77,11 @@ export class SamModalComponent implements OnInit {
   @Input() condensed: boolean = false;
 
   /**
+   * Defines aria level for modal title
+   */
+  @Input() headerLevel: number;
+
+  /**
    * (deprecated) Emitted event when modal is opened
    */
   @Output() onOpen: EventEmitter<any> = new EventEmitter<any>();

--- a/src/ui-kit/components/modal/modal.template.html
+++ b/src/ui-kit/components/modal/modal.template.html
@@ -1,6 +1,6 @@
 <div *ngIf="show" class="modal-backdrop"></div>
 <div aria-live="assertive" aria-modal="true" #modalRoot *ngIf="show" [attr.id]="id" role="dialog" [class]="condensed ? 'modal-dialog-condensed modal-dialog' :'modal-dialog'"
-	 (keydown)="closeEscape($event)" aria-labelledby="dialog-title" aria-describedby="dialog-description">
+	 (keydown)="closeEscape($event)" [attr.aria-labelledby]="id + '-dialog-title'" [attr.aria-describedby]="id + '-dialog-description'">
 	<div #modalContent class="modal-content" tabindex="-1" sam-click-outside (clickOutside)="closeOnOutsideClick && clickOutsideReady ? closeModal() : 0">
 		<div *ngIf="this.type !== 'primary'" class="usa-alert {{this.types[type].class}}">
 			<div [class]="((this.type == 'plain') && (condensed))? 'usa-alert-body plain-alert-body' : 'usa-alert-body'">
@@ -9,7 +9,10 @@
 						class="usa-sr-only">close
 						modal</span></button>
 				<span *ngIf="this.types[type].sr" class="sr-only">{{this.types[type].sr}}</span>
-				<h3 id="dialog-title" class="usa-alert-heading">{{title}}</h3>
+				<h3 *ngIf="!headerLevel" [attr.id]="id + '-dialog-title'" class="usa-alert-heading" >{{title}}</h3>
+				<div *ngIf="headerLevel" [attr.id]="id + '-dialog-title'" class="usa-alert-heading" 
+					role="heading" [attr.aria-level]="headerLevel">{{title}}
+				</div>
 			</div>
 		</div>
 		<div *ngIf="this.type === 'primary'" class="primary-model-body">
@@ -20,11 +23,12 @@
 				<ng-container *ngIf="icon">
 					<sam-icon [icon]="icon" size="2x"></sam-icon>
 				</ng-container>
-				<h3 id="dialog-title">{{title}}</h3>
+				<h3 *ngIf="!headerLevel" [attr.id]="id + '-dialog-title'">{{title}}</h3>
+				<div *ngIf="headerLevel" [attr.id]="id + '-dialog-title'" role="heading" [attr.aria-level]="headerLevel">{{title}}</div>
 			</div>
 		</div>
 		<div class="modal-body">
-			<p id="dialog-description" *ngIf="description">{{description}}</p>
+			<p [attr.id]="id + '-dialog-description'" *ngIf="description">{{description}}</p>
 			<ng-content></ng-content>
 			<div *ngIf="cancelButtonLabel || submitButtonLabel" [ngClass]="(buttonPosition=='left') ? 'text-left' : ((buttonPosition=='right') ? 'text-right' : 'text-center')">
 				<sam-button buttonType="tertiary" class="usa-button-outline usa-modal-content-cancel-btn"


### PR DESCRIPTION
## Description
Updates input values for download modal to accept header level. Default header level for dialog title will be h3 if none is provided.
Updates defined id in modal to be dynamic in order to allow multiple modals in the same dom

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

