### PR TITLE
Update lodash dependency to use es version

### DIFF
--- a/src/ui-kit/components/actions/actions-dropdown/actions-dropdown.template.html
+++ b/src/ui-kit/components/actions/actions-dropdown/actions-dropdown.template.html
@@ -7,7 +7,7 @@
   <button #actionButton class="usa-button"
           [attr.id]="name"
           aria-haspopup="true"
-          aria-controls="name+'menu'"
+          [attr.aria-controls]="name+'menu'"
           [attr.aria-label]="ariaLabelButtonText"
           [attr.aria-expanded]="showActions ? 'true' : undefined"
           (click)="toggleActions()"

--- a/src/ui-kit/form-controls/autocomplete/autocomplete.component.ts
+++ b/src/ui-kit/form-controls/autocomplete/autocomplete.component.ts
@@ -39,6 +39,8 @@ export interface SamCache {
   clearCache();
 }
 
+let nextId = 0;
+
 @Component({
   selector: 'sam-autocomplete',
   templateUrl: 'autocomplete.template.html',
@@ -63,7 +65,7 @@ export class SamAutocompleteComponent
   /**
   * Sets the id attribute
   */
-  @Input() public id: string;
+  @Input() public id: string = `sam-autocomplete-${nextId++}`;
   /**
   * Sets the label text
   */

--- a/src/ui-kit/form-controls/autocomplete/autocomplete.template.html
+++ b/src/ui-kit/form-controls/autocomplete/autocomplete.template.html
@@ -4,15 +4,17 @@
   <sam-label-wrapper #wrapper [label]="labelText" [hint]="hint" [showFullHint]="showFullHint" [name]="id"
     [required]="required" [errorMessage]="errorMessage">
     <div class="input-container">
-      <div role="combobox" [attr.id]="id+'-container'"
+      <div [attr.id]="id+'-container'"
         [attr.aria-owns]="results && results.length > 0 ? 'sam-autocomplete-results' : filteredKeyValuePairs && filteredKeyValuePairs.length > 0  ? 'sam-autocomplete-results-kv':undefined"
-        [attr.aria-expanded]="(((filteredKeyValuePairs && filteredKeyValuePairs.length > 0) || (displayFreeTextKeyValueResults()) ) && hasFocus)
-        ||(((results && results.length > 0) || (displayFreeTextSimpleResults())) && hasFocus)
-        ">
-        <input [attr.id]="id" [attr.tabindex]="tabIndex" #input autocomplete="off"
+       >
+        <input role="combobox" [attr.id]="id" [attr.tabindex]="tabIndex" #input autocomplete="off"
+          [attr.aria-expanded]="(((filteredKeyValuePairs && filteredKeyValuePairs.length > 0) || 
+            (displayFreeTextKeyValueResults()) ) && hasFocus) ||(((results && results.length > 0) || 
+            (displayFreeTextSimpleResults())) && hasFocus)"
+          aria-autocomplete="list"
           [attr.placeholder]="config?.placeholder" [attr.title]="config?.title" [attr.name]="name" [attr.aria-label]="labelText" type="text"
           (focus)="inputFocusHandler($event)"   (keydown)="onKeydown($event)" [(ngModel)]="inputValue"
-          (ngModelChange)="onChange()" [attr.aria-activedescendant]="activeDescendant" aria-autocomplete="list"
+          (ngModelChange)="onChange()" [attr.aria-activedescendant]="activeDescendant"
           [attr.aria-controls]="results && results.length > 0 ? 'sam-autocomplete-results' : filteredKeyValuePairs && filteredKeyValuePairs.length > 0  ? 'sam-autocomplete-results-kv':undefined">
       </div>
       <span *ngIf="config && config.addOnIconClass && config.addOnIconName" (click)="addOnIconClick()" class="add-on"

--- a/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.html
+++ b/src/ui-kit/form-controls/sam-sds-autocomplete/autocomplete-search/autocomplete-search.component.html
@@ -1,8 +1,8 @@
 <div sam-click-outside (clickOutside)="clickOutSide($event)" sam-tab-outside (tabOutside)="clickOutSide($event)">
   <div class="input-container">
-    <div role="combobox" [attr.id]="configuration.id + '-container'" [attr.aria-expanded]="showResults"
-      [attr.aria-owns]="showResults ? configuration.id + '-listbox' : undefined" aria-haspopup="listbox">
-      <input [disabled]="disabled" (keypress)="onkeypress($event)" (input)="textChange($event)"
+    <div [attr.id]="configuration.id + '-container'"
+      [attr.aria-owns]="showResults ? configuration.id + '-listbox' : undefined" >
+      <input role="combobox" [disabled]="disabled"  [attr.aria-expanded]="showResults" (keypress)="onkeypress($event)" (input)="textChange($event)"
         class="usa-input padding-right-3" [ngClass]="getClass()" #input
         [attr.aria-label]="configuration.ariaLabelText ? configuration.ariaLabelText : configuration.labelText"
         [attr.id]="configuration.id" type="text" (focus)="inputFocusHandler()" (keydown)="onKeydown($event)"


### PR DESCRIPTION
## Description
Remove dependency on lodash and instead use lodash-es. We're only using lodash in one location for equality check

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

